### PR TITLE
make .actionBar and actionBar.span size better with uncommon font-sizes

### DIFF
--- a/holo-base-widgets.css
+++ b/holo-base-widgets.css
@@ -1,6 +1,5 @@
 body {
-	padding-top:44px;
-	padding-bottom:44px;
+	padding: 3em 1em;
 }
 
 .actionBar, .holo-actionBar { /* the top action bar should be a <header> element */
@@ -12,7 +11,7 @@ body {
 	top: 0px;
 	left: 0px;
 	right: 0px;
-	height: 40px;
+	height: 3em;
 	
 	border-style: solid none;
 	border-width: 1px 0 2px;
@@ -22,8 +21,8 @@ body {
 }
 
 footer.actionBar, footer.holo-actionBar { /* a bottom action bar must be a <footer> element */
-	top:auto;
-	bottom:0px;
+	top: auto;
+	bottom: 0px;
 	
 	border-width: 1px 0 0;
 	
@@ -33,8 +32,9 @@ footer.actionBar, footer.holo-actionBar { /* a bottom action bar must be a <foot
 }
 
 .actionBar span, .holo-actionBar span { /* use this for text in action bars */
-	display:inline-block;
-	margin:12px;
+	display: inline-block;
+	line-height: 3em;
+	margin: 0 1em;
 }
 
 .actionBar button, .holo-actionBar button {
@@ -46,32 +46,32 @@ footer.actionBar, footer.holo-actionBar { /* a bottom action bar must be a <foot
 	padding-top: 1px;
 	padding-bottom: 2px;
 	
-	background-color:transparent;
-	background-image:none;
+	background-color: transparent;
+	background-image: none;
 	
-	border-style:none;
-	border-width:0px;
-	outline-style:solid;
-	outline-width:2px;
-	outline-color:transparent;
-	outline-offset:-2px;
-	-webkit-border-radius:0px;
-	   -moz-border-radius:0px;
-	        border-radius:0px;
+	border-style: none;
+	border-width: 0px;
+	outline-style: solid;
+	outline-width: 2px;
+	outline-color: transparent;
+	outline-offset: -2px;
+	-webkit-border-radius: 0px;
+	   -moz-border-radius: 0px;
+	        border-radius: 0px;
 	
-	-webkit-box-shadow:none;
-	   -moz-box-shadow:none;
-	        box-shadow:none;
+	-webkit-box-shadow: none;
+	   -moz-box-shadow: none;
+	        box-shadow: none;
 	
-	font-size:9pt;
-	text-transform:uppercase;
-	font-weight:bold;
+	font-size: 9pt;
+	text-transform: uppercase;
+	font-weight: bold;
 	
-	-webkit-transition-duration:0.1s;
-	   -moz-transition-duration:0.1s;
-	    -ms-transition-duration:0.1s;
-	     -o-transition-duration:0.1s;
-	        transition-duration:0.1s;
+	-webkit-transition-duration: 0.1s;
+	   -moz-transition-duration: 0.1s;
+	    -ms-transition-duration: 0.1s;
+	     -o-transition-duration: 0.1s;
+	        transition-duration: 0.1s;
 }
 	footer.actionBar button, footer.holo-actionBar button {
 		margin-bottom: 0;


### PR DESCRIPTION
changed static sizes for actionBar to ems, because if a larger font-size is used, the text would (IDK i haven't tried it on all browsers) likely overflow out of the actionBar itself. I've attached an image:

![first](https://f.cloud.github.com/assets/4211302/2378138/62069890-a88b-11e3-8ed7-77c3a7982754.png)

and after the commit:

![after](https://f.cloud.github.com/assets/4211302/2378140/6a30b488-a88b-11e3-8e9a-e7346385742d.png)

Here, the actionBar is:
|
(TEXT)
|

(where '|' denotes one em)

So the text is properly aligned in the middle, with 1em margin (line-height to be precise) vertically, and 1em horizontally. I have also changed `body`'s padding to match this change.
